### PR TITLE
ci: add Ruby 4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Resolves #6. Adds Ruby 4.0 to the CI matrix as requested.