### PR TITLE
chore(ci): run pull_request workflows on all branches and sync specs to v0.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-
+  pull_request: {}
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- update CI pull_request trigger to run on all branches (`pull_request: {}`)
- sync `specs` submodule to latest API spec tag (`v0.10.0`) where applicable

## Why
- stacked PR branches need CI visibility before merge to `main`
