### PR TITLE
ci: validate PR titles for release-please

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,29 @@
+name: Semantic Pull Request
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            revert
+            docs
+            style
+            chore
+            refactor
+            test
+            build
+            ci


### PR DESCRIPTION
## Summary
- add a semantic pull request workflow using amannn/action-semantic-pull-request@v5
- enforce Conventional Commit PR titles for opened, edited, and synchronized pull requests
- protect release-please from malformed squash-merge titles

## Why
This repository uses release-please, and Altertable squash-merges pull requests. That makes the PR title the merged commit subject that release-please uses for changelog generation and version bump detection.

## Testing
- not applicable (GitHub Actions workflow only)