### PR TITLE
feat: add v0.11.0 lakehouse operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ client.append(
   catalog: "main",
   schema: "public",
   table: "events",
-  payload: { user_id: 123, event: "signup", timestamp: Time.now.iso8601 }
+  payload: { user_id: 123, event: "signup", timestamp: Time.now.iso8601 },
+  sync: true
 )
 
 # Query data
@@ -94,15 +95,19 @@ client.append(
   ]
 )
 
-# Override credentials per-request
-client.append(
+# Asynchronous append with task polling
+resp = client.append(
   catalog: "main",
   schema: "public",
   table: "events",
   payload: { user_id: 789 },
-  username: "other_user",
-  password: "other_password"
+  sync: false
 )
+
+if resp.task_id
+  task = client.get_task(resp.task_id)
+  puts task.status
+end
 ```
 
 ### `query_all`
@@ -111,7 +116,8 @@ Executes a SQL query and returns all rows in memory (accumulated).
 
 ```ruby
 result = client.query_all(
-  statement: "SELECT * FROM main.public.events LIMIT 10"
+  statement: "SELECT * FROM main.public.events LIMIT 10",
+  cache: true
 )
 
 puts result[:metadata] # Hash
@@ -178,6 +184,30 @@ Validates a SQL statement without executing it.
 resp = client.validate(statement: "SELECT * FROM invalid_table")
 puts resp.valid # => false
 puts resp.error
+```
+
+### `get_task`
+
+Retrieves the status of an asynchronous append task.
+
+```ruby
+task = client.get_task("task-uuid")
+puts task.status # "pending" or "completed"
+```
+
+### `autocomplete`
+
+Returns SQL autocomplete suggestions.
+
+```ruby
+resp = client.autocomplete(
+  statement: "SEL",
+  max_suggestions: 5
+)
+
+resp.suggestions.each do |suggestion|
+  puts suggestion.suggestion
+end
 ```
 
 ## Configuration

--- a/lib/altertable/lakehouse/client.rb
+++ b/lib/altertable/lakehouse/client.rb
@@ -43,11 +43,18 @@ module Altertable
       end
 
       # POST /append
-      def append(catalog:, schema:, table:, payload:)
+      def append(catalog:, schema:, table:, payload:, sync: nil)
         params = { catalog: catalog, schema: schema, table: table }
+        params[:sync] = sync unless sync.nil?
         req = Models::AppendRequest.new(payload)
         resp = request(:post, "/append", body: req.to_h, query: params)
         Models::AppendResponse.from_h(resp)
+      end
+
+      # GET /tasks/:task_id
+      def get_task(task_id)
+        resp = request(:get, "/tasks/#{task_id}")
+        Models::TaskResponse.from_h(resp)
       end
 
       # POST /query (streamed)
@@ -109,10 +116,28 @@ module Altertable
       end
 
       # POST /validate
-      def validate(statement:)
-        req = Models::ValidateRequest.new(statement: statement)
+      def validate(statement:, catalog: nil, schema: nil, session_id: nil)
+        req = Models::ValidateRequest.new(
+          statement: statement,
+          catalog: catalog,
+          schema: schema,
+          session_id: session_id
+        )
         resp = request(:post, "/validate", body: req.to_h)
         Models::ValidateResponse.from_h(resp)
+      end
+
+      # POST /autocomplete
+      def autocomplete(statement:, catalog: nil, schema: nil, session_id: nil, max_suggestions: nil)
+        req = Models::AutocompleteRequest.new(
+          statement: statement,
+          catalog: catalog,
+          schema: schema,
+          session_id: session_id,
+          max_suggestions: max_suggestions
+        )
+        resp = request(:post, "/autocomplete", body: req.to_h)
+        Models::AutocompleteResponse.from_h(resp)
       end
 
       private

--- a/lib/altertable/lakehouse/models.rb
+++ b/lib/altertable/lakehouse/models.rb
@@ -21,22 +21,42 @@ module Altertable
       end
 
       class AppendResponse < Request
-        attr_reader :ok, :error_code
+        attr_reader :ok, :error_code, :error_message, :task_id
 
-        def initialize(ok:, error_code: nil)
+        def initialize(ok:, error_code: nil, error_message: nil, task_id: nil)
           @ok = ok
           @error_code = error_code
+          @error_message = error_message
+          @task_id = task_id
         end
 
         def self.from_h(h)
-          new(ok: h["ok"], error_code: h["error_code"])
+          new(
+            ok: h["ok"],
+            error_code: h["error_code"],
+            error_message: h["error_message"],
+            task_id: h["task_id"]
+          )
+        end
+      end
+
+      class TaskResponse < Request
+        attr_reader :task_id, :status
+
+        def initialize(task_id:, status:)
+          @task_id = task_id
+          @status = status
+        end
+
+        def self.from_h(h)
+          new(task_id: h["task_id"], status: h["status"])
         end
       end
 
       class QueryRequest < Request
-        attr_reader :statement, :catalog, :schema, :session_id, :compute_size, :sanitize, :limit, :offset, :timezone, :ephemeral, :visible, :requested_by, :query_id
+        attr_reader :statement, :catalog, :schema, :session_id, :compute_size, :sanitize, :limit, :offset, :timezone, :ephemeral, :visible, :requested_by, :query_id, :cache
 
-        def initialize(statement:, catalog: nil, schema: nil, session_id: nil, compute_size: nil, sanitize: nil, limit: nil, offset: nil, timezone: nil, ephemeral: nil, visible: nil, requested_by: nil, query_id: nil)
+        def initialize(statement:, catalog: nil, schema: nil, session_id: nil, compute_size: nil, sanitize: nil, limit: nil, offset: nil, timezone: nil, ephemeral: nil, visible: nil, requested_by: nil, query_id: nil, cache: nil)
           @statement = statement
           @catalog = catalog
           @schema = schema
@@ -50,6 +70,7 @@ module Altertable
           @visible = visible
           @requested_by = requested_by
           @query_id = query_id
+          @cache = cache
         end
 
         def to_h
@@ -66,19 +87,27 @@ module Altertable
           h[:visible] = @visible unless @visible.nil?
           h[:requested_by] = @requested_by if @requested_by
           h[:query_id] = @query_id if @query_id
+          h[:cache] = @cache unless @cache.nil?
           h
         end
       end
 
       class ValidateRequest < Request
-        attr_reader :statement
+        attr_reader :statement, :catalog, :schema, :session_id
 
-        def initialize(statement:)
+        def initialize(statement:, catalog: nil, schema: nil, session_id: nil)
           @statement = statement
+          @catalog = catalog
+          @schema = schema
+          @session_id = session_id
         end
 
         def to_h
-          { statement: @statement }
+          h = { statement: @statement }
+          h[:catalog] = @catalog if @catalog
+          h[:schema] = @schema if @schema
+          h[:session_id] = @session_id if @session_id
+          h
         end
       end
 
@@ -150,6 +179,67 @@ module Altertable
         
         def self.from_h(h)
           new(cancelled: h["cancelled"], message: h["message"])
+        end
+      end
+
+      class AutocompleteRequest < Request
+        attr_reader :statement, :catalog, :schema, :session_id, :max_suggestions
+
+        def initialize(statement:, catalog: nil, schema: nil, session_id: nil, max_suggestions: nil)
+          @statement = statement
+          @catalog = catalog
+          @schema = schema
+          @session_id = session_id
+          @max_suggestions = max_suggestions
+        end
+
+        def to_h
+          h = { statement: @statement }
+          h[:catalog] = @catalog if @catalog
+          h[:schema] = @schema if @schema
+          h[:session_id] = @session_id if @session_id
+          h[:max_suggestions] = @max_suggestions if @max_suggestions
+          h
+        end
+      end
+
+      class AutocompleteSuggestion < Request
+        attr_reader :suggestion, :suggestion_start, :suggestion_type, :suggestion_score, :extra_char
+
+        def initialize(suggestion:, suggestion_start:, suggestion_type:, suggestion_score:, extra_char: nil)
+          @suggestion = suggestion
+          @suggestion_start = suggestion_start
+          @suggestion_type = suggestion_type
+          @suggestion_score = suggestion_score
+          @extra_char = extra_char
+        end
+
+        def self.from_h(h)
+          new(
+            suggestion: h["suggestion"],
+            suggestion_start: h["suggestion_start"],
+            suggestion_type: h["suggestion_type"],
+            suggestion_score: h["suggestion_score"],
+            extra_char: h["extra_char"]
+          )
+        end
+      end
+
+      class AutocompleteResponse < Request
+        attr_reader :suggestions, :statement, :connections_errors
+
+        def initialize(suggestions:, statement:, connections_errors:)
+          @suggestions = suggestions
+          @statement = statement
+          @connections_errors = connections_errors
+        end
+
+        def self.from_h(h)
+          new(
+            suggestions: Array(h["suggestions"]).map { |suggestion| AutocompleteSuggestion.from_h(suggestion) },
+            statement: h["statement"],
+            connections_errors: h["connections_errors"] || {}
+          )
         end
       end
     end

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -41,12 +41,14 @@ RSpec.describe Altertable::Lakehouse::Client do
 
   describe "#append" do
     it "appends a row and returns ok: true" do
+      table_name = "append_events_#{SecureRandom.hex(4)}"
+
       # Ensure the table exists first via upload (CSV create)
       csv = "user_id,name\n1,Alice\n"
       client.upload(
         catalog: "memory",
         schema: "main",
-        table: "append_events",
+        table: table_name,
         format: "csv",
         mode: "create",
         file_io: StringIO.new(csv)
@@ -55,9 +57,33 @@ RSpec.describe Altertable::Lakehouse::Client do
       resp = client.append(
         catalog: "memory",
         schema: "main",
-        table: "append_events",
+        table: table_name,
         payload: { user_id: 2, name: "Bob" }
       )
+      expect(resp.ok).to be true
+    end
+
+    it "supports the sync query parameter" do
+      table_name = "append_events_sync_#{SecureRandom.hex(4)}"
+
+      csv = "user_id,name\n1,Alice\n"
+      client.upload(
+        catalog: "memory",
+        schema: "main",
+        table: table_name,
+        format: "csv",
+        mode: "create",
+        file_io: StringIO.new(csv)
+      )
+
+      resp = client.append(
+        catalog: "memory",
+        schema: "main",
+        table: table_name,
+        payload: { user_id: 2, name: "Bob" },
+        sync: true
+      )
+
       expect(resp.ok).to be true
     end
 
@@ -125,6 +151,15 @@ RSpec.describe Altertable::Lakehouse::Client do
       expect(result[:columns]).to eq(["x", "y"])
       expect(result[:rows]).to eq([{ "x" => 7, "y" => "hello" }])
     end
+
+    it "forwards the cache option" do
+      result = client.query_all(
+        statement: "SELECT 1 AS cached_value",
+        cache: true
+      )
+
+      expect(result[:rows]).to eq([{ "cached_value" => 1 }])
+    end
   end
 
   # ── error handling ───────────────────────────────────────────────────────────
@@ -152,17 +187,18 @@ RSpec.describe Altertable::Lakehouse::Client do
 
   describe "#upload" do
     it "creates a table from CSV in create mode and allows querying it" do
+      table_name = "upload_test_#{SecureRandom.hex(4)}"
       csv = "id,score\n10,100\n20,200\n"
       client.upload(
         catalog: "memory",
         schema: "main",
-        table: "upload_test",
+        table: table_name,
         format: "csv",
         mode: "create",
         file_io: StringIO.new(csv)
       )
 
-      result = client.query_all(statement: "SELECT * FROM upload_test ORDER BY id")
+      result = client.query_all(statement: "SELECT * FROM #{table_name} ORDER BY id")
       expect(result[:columns]).to eq(["id", "score"])
       expect(result[:rows]).to eq([
         { "id" => 10, "score" => 100 },
@@ -184,6 +220,16 @@ RSpec.describe Altertable::Lakehouse::Client do
       resp = client.validate(statement: "NOT VALID SQL !!!")
       expect(resp.valid).to be false
       expect(resp.error).to be_a(String)
+    end
+
+    it "accepts optional request fields" do
+      resp = client.validate(
+        statement: "SELECT 1",
+        catalog: "memory",
+        schema: "main"
+      )
+
+      expect(resp.valid).to be true
     end
   end
 
@@ -232,6 +278,38 @@ RSpec.describe Altertable::Lakehouse::Client do
 
       resp = client.cancel_query(query_id, session_id: session_id)
       expect(resp.cancelled).to be true
+    end
+  end
+
+  # ── #get_task ───────────────────────────────────────────────────────────────
+
+  describe "#get_task" do
+    it "returns task status from the tasks endpoint" do
+      adapter = client.instance_variable_get(:@adapter)
+      response = Altertable::Lakehouse::Adapters::Response.new(
+        200,
+        { task_id: "task-123", status: "completed" }.to_json,
+        {}
+      )
+
+      allow(adapter).to receive(:get).and_return(response)
+
+      task = client.get_task("task-123")
+      expect(task.task_id).to eq("task-123")
+      expect(task.status).to eq("completed")
+    end
+  end
+
+  # ── #autocomplete ───────────────────────────────────────────────────────────
+
+  describe "#autocomplete" do
+    it "returns autocomplete suggestions" do
+      resp = client.autocomplete(statement: "SEL", max_suggestions: 5)
+
+      expect(resp.statement).to eq("SEL")
+      expect(resp.suggestions.length).to be <= 5
+      expect(resp.suggestions).not_to be_empty
+      expect(resp.suggestions.first.suggestion).to be_a(String)
     end
   end
 end


### PR DESCRIPTION
## Summary
- update the `specs` submodule to `v0.11.0`
- add the missing `v0.11.0` Lakehouse operations in the Ruby client
- expand the test suite and README for the new surface area

## Added
- `append(sync:)`
- `get_task`
- `autocomplete`
- `task_id`, `error_message`, and `cache` request/response support

## Verification
- `CI=1 ALTERTABLE_MOCK_PORT=32769 bundle exec rspec spec/altertable/lakehouse_spec.rb spec/altertable/lakehouse/adapter_selection_spec.rb --format documentation`
