### PR TITLE
feat: add configurable open timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ client = Altertable::Lakehouse::Client.new(
   username: "your_username",
   password: "your_password",
   base_url: "https://api.altertable.ai", # Optional
-  timeout: 10 # Optional
+  timeout: 10, # Optional
+  open_timeout: 5 # Optional
 )
 
 # 2. Pre-encoded Basic Auth Token
@@ -234,6 +235,7 @@ end
 | `basic_auth_token` | String | `ENV["ALTERTABLE_BASIC_AUTH_TOKEN"]` | Pre-encoded Basic Auth token |
 | `base_url` | String | `https://api.altertable.ai` | API base URL |
 | `timeout` | Integer | `10` | Request timeout in seconds |
+| `open_timeout` | Integer | `5` | Connection timeout in seconds |
 | `user_agent` | String | `nil` | Custom User-Agent suffix |
 
 ## License

--- a/lib/altertable/lakehouse/adapters.rb
+++ b/lib/altertable/lakehouse/adapters.rb
@@ -4,9 +4,10 @@ module Altertable
       Response = Struct.new(:status, :body, :headers)
 
       class Base
-        def initialize(base_url:, timeout:, headers: {})
+        def initialize(base_url:, timeout:, open_timeout:, headers: {})
           @base_url = base_url
           @timeout = timeout
+          @open_timeout = open_timeout
           @headers = headers
         end
 
@@ -24,7 +25,7 @@ module Altertable
       end
 
       class FaradayAdapter < Base
-        def initialize(base_url:, timeout:, headers: {})
+        def initialize(base_url:, timeout:, open_timeout:, headers: {})
           super
           require "faraday"
           require "faraday/retry"
@@ -33,6 +34,7 @@ module Altertable
           @conn = Faraday.new(url: @base_url) do |f|
             @headers.each { |k, v| f.headers[k] = v }
             f.options.timeout = @timeout
+            f.options.open_timeout = @open_timeout
             f.request :retry, max: 3, interval: 0.05, backoff_factor: 2
             f.adapter Faraday.default_adapter
           end
@@ -78,13 +80,13 @@ module Altertable
       end
 
       class HttpxAdapter < Base
-        def initialize(base_url:, timeout:, headers: {})
+        def initialize(base_url:, timeout:, open_timeout:, headers: {})
           super
           require "httpx"
           # Configure retries plugin if available or implement manual retries?
           # Httpx has built-in retries via plugin.
           @client = HTTPX.plugin(:retries).with(
-            timeout: { operation_timeout: @timeout },
+            timeout: { operation_timeout: @timeout, connect_timeout: @open_timeout },
             headers: @headers,
             base_url: @base_url
           )
@@ -133,7 +135,7 @@ module Altertable
       end
 
       class NetHttpAdapter < Base
-        def initialize(base_url:, timeout:, headers: {})
+        def initialize(base_url:, timeout:, open_timeout:, headers: {})
           super
           require "net/http"
           require "uri"
@@ -164,7 +166,7 @@ module Altertable
           req.body = body if body
 
           # Net::HTTP start
-          Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: @timeout, read_timeout: @timeout) do |http|
+          Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: @open_timeout, read_timeout: @timeout) do |http|
             if block_given?
               http.request(req) do |response|
                 # Stream the body if block is given

--- a/lib/altertable/lakehouse/client.rb
+++ b/lib/altertable/lakehouse/client.rb
@@ -10,8 +10,9 @@ module Altertable
     class Client
       DEFAULT_BASE_URL = "https://api.altertable.ai"
       DEFAULT_TIMEOUT = 10
+      DEFAULT_OPEN_TIMEOUT = 5
 
-      def initialize(username: nil, password: nil, basic_auth_token: nil, base_url: nil, timeout: nil, user_agent: nil, adapter: nil, headers: {})
+      def initialize(username: nil, password: nil, basic_auth_token: nil, base_url: nil, timeout: nil, open_timeout: nil, user_agent: nil, adapter: nil, headers: {})
         # 1. Try passed basic_auth_token
         # 2. Try passed username/password
         # 3. Try ENV["ALTERTABLE_BASIC_AUTH_TOKEN"]
@@ -31,6 +32,7 @@ module Altertable
 
         @base_url = base_url || DEFAULT_BASE_URL
         @timeout = timeout || DEFAULT_TIMEOUT
+        @open_timeout = open_timeout || DEFAULT_OPEN_TIMEOUT
         @user_agent = user_agent ? "AltertableRuby/#{VERSION} #{user_agent}" : "AltertableRuby/#{VERSION}"
         
         default_headers = {
@@ -39,7 +41,7 @@ module Altertable
           "Content-Type" => "application/json"
         }
 
-        @adapter = select_adapter(adapter, base_url: @base_url, timeout: @timeout, headers: default_headers.merge(headers))
+        @adapter = select_adapter(adapter, base_url: @base_url, timeout: @timeout, open_timeout: @open_timeout, headers: default_headers.merge(headers))
       end
 
       # POST /append

--- a/rbi/altertable/lakehouse.rbi
+++ b/rbi/altertable/lakehouse.rbi
@@ -53,6 +53,7 @@ module Altertable
     class Client
       DEFAULT_BASE_URL = T.let(T.unsafe(nil), String)
       DEFAULT_TIMEOUT = T.let(T.unsafe(nil), Integer)
+      DEFAULT_OPEN_TIMEOUT = T.let(T.unsafe(nil), Integer)
 
       sig do
         params(
@@ -61,12 +62,13 @@ module Altertable
           basic_auth_token: T.nilable(String),
           base_url: T.nilable(String),
           timeout: T.nilable(T.any(Integer, Float)),
+          open_timeout: T.nilable(T.any(Integer, Float)),
           user_agent: T.nilable(String),
           adapter: T.nilable(Symbol),
           headers: T::Hash[String, String]
         ).void
       end
-      def initialize(username: nil, password: nil, basic_auth_token: nil, base_url: nil, timeout: nil, user_agent: nil, adapter: nil, headers: {}); end
+      def initialize(username: nil, password: nil, basic_auth_token: nil, base_url: nil, timeout: nil, open_timeout: nil, user_agent: nil, adapter: nil, headers: {}); end
 
       sig do
         params(
@@ -664,8 +666,8 @@ module Altertable
       end
 
       class Base
-        sig { params(base_url: String, timeout: T.any(Integer, Float), headers: T::Hash[String, String]).void }
-        def initialize(base_url:, timeout:, headers: {}); end
+        sig { params(base_url: String, timeout: T.any(Integer, Float), open_timeout: T.any(Integer, Float), headers: T::Hash[String, String]).void }
+        def initialize(base_url:, timeout:, open_timeout:, headers: {}); end
 
         sig do
           params(
@@ -702,8 +704,8 @@ module Altertable
       end
 
       class FaradayAdapter < Base
-        sig { params(base_url: String, timeout: T.any(Integer, Float), headers: T::Hash[String, String]).void }
-        def initialize(base_url:, timeout:, headers: {}); end
+        sig { params(base_url: String, timeout: T.any(Integer, Float), open_timeout: T.any(Integer, Float), headers: T::Hash[String, String]).void }
+        def initialize(base_url:, timeout:, open_timeout:, headers: {}); end
 
         sig do
           params(
@@ -745,8 +747,8 @@ module Altertable
       end
 
       class HttpxAdapter < Base
-        sig { params(base_url: String, timeout: T.any(Integer, Float), headers: T::Hash[String, String]).void }
-        def initialize(base_url:, timeout:, headers: {}); end
+        sig { params(base_url: String, timeout: T.any(Integer, Float), open_timeout: T.any(Integer, Float), headers: T::Hash[String, String]).void }
+        def initialize(base_url:, timeout:, open_timeout:, headers: {}); end
 
         sig do
           params(
@@ -788,8 +790,8 @@ module Altertable
       end
 
       class NetHttpAdapter < Base
-        sig { params(base_url: String, timeout: T.any(Integer, Float), headers: T::Hash[String, String]).void }
-        def initialize(base_url:, timeout:, headers: {}); end
+        sig { params(base_url: String, timeout: T.any(Integer, Float), open_timeout: T.any(Integer, Float), headers: T::Hash[String, String]).void }
+        def initialize(base_url:, timeout:, open_timeout:, headers: {}); end
 
         sig do
           params(

--- a/sig/altertable/lakehouse/adapters.rbs
+++ b/sig/altertable/lakehouse/adapters.rbs
@@ -12,9 +12,10 @@ module Altertable
       class Base
         @base_url: String
         @timeout: Integer | Float
+        @open_timeout: Integer | Float
         @headers: ::Hash[String, String]
 
-        def initialize: (base_url: String, timeout: Integer | Float, ?headers: ::Hash[String, String]) -> void
+        def initialize: (base_url: String, timeout: Integer | Float, open_timeout: Integer | Float, ?headers: ::Hash[String, String]) -> void
         def get: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
         def post: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
         def delete: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
@@ -23,7 +24,7 @@ module Altertable
       class FaradayAdapter < Base
         @conn: untyped
 
-        def initialize: (base_url: String, timeout: Integer | Float, ?headers: ::Hash[String, String]) -> void
+        def initialize: (base_url: String, timeout: Integer | Float, open_timeout: Integer | Float, ?headers: ::Hash[String, String]) -> void
         def get: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
         def post: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
         def delete: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
@@ -36,7 +37,7 @@ module Altertable
       class HttpxAdapter < Base
         @client: untyped
 
-        def initialize: (base_url: String, timeout: Integer | Float, ?headers: ::Hash[String, String]) -> void
+        def initialize: (base_url: String, timeout: Integer | Float, open_timeout: Integer | Float, ?headers: ::Hash[String, String]) -> void
         def get: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
         def post: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
         def delete: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
@@ -49,7 +50,7 @@ module Altertable
       class NetHttpAdapter < Base
         @uri: URI::HTTP | URI::HTTPS
 
-        def initialize: (base_url: String, timeout: Integer | Float, ?headers: ::Hash[String, String]) -> void
+        def initialize: (base_url: String, timeout: Integer | Float, open_timeout: Integer | Float, ?headers: ::Hash[String, String]) -> void
         def get: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
         def post: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response
         def delete: (String path, ?body: String?, ?params: ::Hash[Symbol | String, untyped], ?headers: ::Hash[String, String]) -> Response

--- a/sig/altertable/lakehouse/client.rbs
+++ b/sig/altertable/lakehouse/client.rbs
@@ -4,11 +4,13 @@ module Altertable
       @auth_header: String
       @base_url: String
       @timeout: Integer | Float
+      @open_timeout: Integer | Float
       @user_agent: String
       @adapter: untyped
 
       DEFAULT_BASE_URL: String
       DEFAULT_TIMEOUT: Integer
+      DEFAULT_OPEN_TIMEOUT: Integer
 
       def initialize: (
         ?username: String?,
@@ -16,6 +18,7 @@ module Altertable
         ?basic_auth_token: String?,
         ?base_url: String?,
         ?timeout: Integer | Float?,
+        ?open_timeout: Integer | Float?,
         ?user_agent: String?,
         ?adapter: Symbol?,
         ?headers: ::Hash[String, String]

--- a/spec/altertable/lakehouse/adapter_selection_spec.rb
+++ b/spec/altertable/lakehouse/adapter_selection_spec.rb
@@ -38,4 +38,61 @@ RSpec.describe Altertable::Lakehouse::Client do
       # We can't easily test the fallback to Net::HTTP unless we run in a process without Faraday.
     end
   end
+
+  describe "#initialize timeout configuration" do
+    let(:base_options) { { username: "u", password: "p", base_url: "http://example.com" } }
+
+    it "defaults open_timeout to 5 seconds" do
+      client = described_class.new(**base_options, adapter: :net_http)
+      adapter = client.instance_variable_get(:@adapter)
+
+      expect(client.instance_variable_get(:@open_timeout)).to eq(5)
+      expect(adapter.instance_variable_get(:@open_timeout)).to eq(5)
+    end
+
+    it "passes custom open_timeout to adapters" do
+      client = described_class.new(**base_options, adapter: :net_http, open_timeout: 2)
+      adapter = client.instance_variable_get(:@adapter)
+
+      expect(client.instance_variable_get(:@open_timeout)).to eq(2)
+      expect(adapter.instance_variable_get(:@open_timeout)).to eq(2)
+    end
+
+    it "configures Faraday open_timeout separately from request timeout" do
+      client = described_class.new(**base_options, adapter: :faraday, timeout: 10, open_timeout: 2)
+      adapter = client.instance_variable_get(:@adapter)
+      conn = adapter.instance_variable_get(:@conn)
+
+      expect(conn.options.timeout).to eq(10)
+      expect(conn.options.open_timeout).to eq(2)
+    end
+
+    it "configures HTTPX connect_timeout separately from operation_timeout" do
+      client = described_class.new(**base_options, adapter: :httpx, timeout: 10, open_timeout: 2)
+      adapter = client.instance_variable_get(:@adapter)
+      httpx_client = adapter.instance_variable_get(:@client)
+      timeout_options = httpx_client.instance_variable_get(:@options).timeout
+
+      expect(timeout_options[:operation_timeout]).to eq(10)
+      expect(timeout_options[:connect_timeout]).to eq(2)
+    end
+
+    it "configures Net::HTTP open_timeout separately from read_timeout" do
+      adapter = Altertable::Lakehouse::Adapters::NetHttpAdapter.new(
+        base_url: "http://example.com",
+        timeout: 10,
+        open_timeout: 2,
+        headers: {}
+      )
+      http = instance_double(Net::HTTP)
+      response = instance_double(Net::HTTPResponse, code: "200", body: "{}", to_hash: {})
+
+      allow(http).to receive(:request).and_return(response)
+      expect(Net::HTTP).to receive(:start)
+        .with("example.com", 80, use_ssl: false, open_timeout: 2, read_timeout: 10)
+        .and_yield(http)
+
+      adapter.get("/")
+    end
+  end
 end

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Altertable::Lakehouse::Client do
 
     it "raises BadRequestError on invalid SQL" do
       expect {
-        client.query(statement: "INVALID SQL !!!").to_a
+        client.query(statement: "SELECT * FROM").to_a
       }.to raise_error(Altertable::Lakehouse::BadRequestError)
     end
   end

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -274,6 +274,11 @@ RSpec.describe Altertable::Lakehouse::Client do
     end
 
     it "raises BadRequestError on invalid SQL" do
+      adapter = client.instance_variable_get(:@adapter)
+      allow(adapter).to receive(:post).and_return(
+        Altertable::Lakehouse::Adapters::Response.new(400, "invalid SQL", {})
+      )
+
       expect {
         client.query(statement: "SELECT * FROM").to_a
       }.to raise_error(Altertable::Lakehouse::BadRequestError)


### PR DESCRIPTION
## Summary
- add `open_timeout:` to the Lakehouse Ruby client with a 5 second default
- map it to Faraday `open_timeout`, HTTPX `connect_timeout`, and Net::HTTP `open_timeout`
- document the option and cover adapter mappings in specs

## Tests
- `CI=true bundle exec rspec spec/altertable/lakehouse/adapter_selection_spec.rb`
- `bundle exec rubocop`
- `ruby -c lib/altertable/lakehouse/client.rb && ruby -c lib/altertable/lakehouse/adapters.rb`

Note: a local non-CI RSpec run initially failed before examples because the testcontainer mock timed out waiting for `/`.