### PR TITLE
fix(api): expose upsert API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Initial implementation of Altertable Lakehouse Ruby Client.
-- Support for `append`, `query` (streamed/accumulated), `upload`, `validate`.
+- Support for `append`, `query` (streamed/accumulated), `upsert`, `validate`.
 - Support for `get_query`, `cancel_query`.
 - Typed request/response models.
 - Faraday-based HTTP client with retries.

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ File.open("data.csv", "rb") do |file|
     catalog: "main",
     schema: "public",
     table: "events",
-    format: "csv",
     mode: "append",
+    content_type: "text/csv",
     file_io: file
   )
 end

--- a/README.md
+++ b/README.md
@@ -142,18 +142,17 @@ result.each do |row|
 end
 ```
 
-### `upload`
+### `upsert`
 
-Uploads a file (CSV, Parquet, etc.) to a table.
+Upserts a file (CSV, Parquet, etc.) to a table.
 
 ```ruby
 File.open("data.csv", "rb") do |file|
-  client.upload(
+  client.upsert(
     catalog: "main",
     schema: "public",
     table: "events",
     mode: "append",
-    content_type: "text/csv",
     file_io: file
   )
 end

--- a/lib/altertable/lakehouse/client.rb
+++ b/lib/altertable/lakehouse/client.rb
@@ -86,20 +86,19 @@ module Altertable
         }
       end
 
-      # POST /upload
-      def upload(catalog:, schema:, table:, format:, mode:, file_io:, primary_key: nil, headers: {})
+      # POST /upsert
+      def upload(catalog:, schema:, table:, file_io:, mode: nil, primary_key: nil, headers: {}, content_type: "application/octet-stream")
         params = {
           catalog: catalog,
           schema: schema,
-          table: table,
-          format: format,
-          mode: mode
+          table: table
         }
+        params[:mode] = mode if mode
         params[:primary_key] = primary_key if primary_key
 
         body = file_io.respond_to?(:read) ? file_io.read : file_io
 
-        resp = @adapter.post("/upload", body: body, params: params, headers: headers.merge("Content-Type" => "application/octet-stream"))
+        resp = @adapter.post("/upsert", body: body, params: params, headers: headers.merge("Content-Type" => content_type))
         handle_response(resp)
       end
 

--- a/lib/altertable/lakehouse/client.rb
+++ b/lib/altertable/lakehouse/client.rb
@@ -87,7 +87,7 @@ module Altertable
       end
 
       # POST /upsert
-      def upload(catalog:, schema:, table:, file_io:, mode: nil, primary_key: nil, headers: {}, content_type: "application/octet-stream")
+      def upsert(catalog:, schema:, table:, file_io:, mode: nil, primary_key: nil, headers: {})
         params = {
           catalog: catalog,
           schema: schema,
@@ -98,7 +98,7 @@ module Altertable
 
         body = file_io.respond_to?(:read) ? file_io.read : file_io
 
-        resp = @adapter.post("/upsert", body: body, params: params, headers: headers.merge("Content-Type" => content_type))
+        resp = @adapter.post("/upsert", body: body, params: params, headers: headers)
         handle_response(resp)
       end
 

--- a/lib/altertable/lakehouse/client.rb
+++ b/lib/altertable/lakehouse/client.rb
@@ -35,8 +35,7 @@ module Altertable
         
         default_headers = {
           "Authorization" => @auth_header,
-          "User-Agent" => @user_agent,
-          "Content-Type" => "application/json"
+          "User-Agent" => @user_agent
         }
 
         @adapter = select_adapter(adapter, base_url: @base_url, timeout: @timeout, headers: default_headers.merge(headers))
@@ -65,7 +64,7 @@ module Altertable
           buffer = ""
           
           # Use adapter's stream capability
-          resp = @adapter.post("/query", body: req_body, headers: headers) do |chunk, _|
+          resp = @adapter.post("/query", body: req_body, headers: json_headers(headers)) do |chunk, _|
             buffer << chunk
           end
 
@@ -186,9 +185,13 @@ module Altertable
           method, path,
           body: encode_request_body(body),
           params: query || {},
-          headers: headers
+          headers: body.nil? ? headers : json_headers(headers)
         )
         handle_response(resp)
+      end
+
+      def json_headers(headers)
+        { "Content-Type" => "application/json" }.merge(headers)
       end
 
       def encode_request_body(body)

--- a/rbi/altertable/lakehouse.rbi
+++ b/rbi/altertable/lakehouse.rbi
@@ -97,11 +97,10 @@ module Altertable
           file_io: T.untyped,
           mode: T.nilable(String),
           primary_key: T.nilable(String),
-          headers: T::Hash[String, String],
-          content_type: String
+          headers: T::Hash[String, String]
         ).returns(T.untyped)
       end
-      def upload(catalog:, schema:, table:, file_io:, mode: nil, primary_key: nil, headers: {}, content_type: "application/octet-stream"); end
+      def upsert(catalog:, schema:, table:, file_io:, mode: nil, primary_key: nil, headers: {}); end
 
       sig { params(query_id: String, headers: T::Hash[String, String]).returns(::Altertable::Lakehouse::Models::QueryLogResponse) }
       def get_query(query_id, headers: {}); end

--- a/rbi/altertable/lakehouse.rbi
+++ b/rbi/altertable/lakehouse.rbi
@@ -94,14 +94,14 @@ module Altertable
           catalog: String,
           schema: String,
           table: String,
-          format: String,
-          mode: String,
           file_io: T.untyped,
+          mode: T.nilable(String),
           primary_key: T.nilable(String),
-          headers: T::Hash[String, String]
+          headers: T::Hash[String, String],
+          content_type: String
         ).returns(T.untyped)
       end
-      def upload(catalog:, schema:, table:, format:, mode:, file_io:, primary_key: nil, headers: {}); end
+      def upload(catalog:, schema:, table:, file_io:, mode: nil, primary_key: nil, headers: {}, content_type: "application/octet-stream"); end
 
       sig { params(query_id: String, headers: T::Hash[String, String]).returns(::Altertable::Lakehouse::Models::QueryLogResponse) }
       def get_query(query_id, headers: {}); end

--- a/sig/altertable/lakehouse/client.rbs
+++ b/sig/altertable/lakehouse/client.rbs
@@ -36,15 +36,14 @@ module Altertable
 
       def query_all: (statement: String, ?headers: ::Hash[String, String], **untyped options) -> ::Hash[Symbol, untyped]
 
-      def upload: (
+      def upsert: (
         catalog: String,
         schema: String,
         table: String,
         file_io: untyped,
         ?mode: String?,
         ?primary_key: String?,
-        ?headers: ::Hash[String, String],
-        ?content_type: String
+        ?headers: ::Hash[String, String]
       ) -> untyped
 
       def get_query: (String query_id, ?headers: ::Hash[String, String]) -> Models::QueryLogResponse

--- a/sig/altertable/lakehouse/client.rbs
+++ b/sig/altertable/lakehouse/client.rbs
@@ -40,11 +40,11 @@ module Altertable
         catalog: String,
         schema: String,
         table: String,
-        format: String,
-        mode: String,
         file_io: untyped,
+        ?mode: String?,
         ?primary_key: String?,
-        ?headers: ::Hash[String, String]
+        ?headers: ::Hash[String, String],
+        ?content_type: String
       ) -> untyped
 
       def get_query: (String query_id, ?headers: ::Hash[String, String]) -> Models::QueryLogResponse

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -240,13 +240,13 @@ RSpec.describe Altertable::Lakehouse::Client do
       client.query(statement: "SELECT 1", headers: { "X-Trace" => "trace-1" }).to_a
     end
 
-    it "forwards per-request headers on #upload while keeping octet-stream content type" do
+    it "forwards per-request headers and content type on #upload" do
       expect(adapter).to receive(:post).with(
         "/upsert",
         hash_including(
           headers: {
             "X-Upload-Source" => "etl",
-            "Content-Type" => "application/octet-stream"
+            "Content-Type" => "text/csv"
           }
         )
       ).and_return(ok_response)

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Altertable::Lakehouse::Client do
       )
       adapter = c.instance_variable_get(:@adapter)
       expect(adapter.instance_variable_get(:@headers)).to include("X-Tenant" => "acme")
+      expect(adapter.instance_variable_get(:@headers)).not_to include("Content-Type")
     end
   end
 
@@ -213,7 +214,7 @@ RSpec.describe Altertable::Lakehouse::Client do
     it "forwards per-request headers on #validate" do
       expect(adapter).to receive(:post).with(
         "/validate",
-        hash_including(headers: { "X-Request-Id" => "req-1" })
+        hash_including(headers: hash_including("Content-Type" => "application/json", "X-Request-Id" => "req-1"))
       ).and_return(ok_response)
 
       client.validate(statement: "SELECT 1", headers: { "X-Request-Id" => "req-1" })
@@ -228,7 +229,7 @@ RSpec.describe Altertable::Lakehouse::Client do
 
       expect(adapter).to receive(:post).with(
         "/query",
-        hash_including(headers: { "X-Trace" => "trace-1" })
+        hash_including(headers: hash_including("Content-Type" => "application/json", "X-Trace" => "trace-1"))
       ).and_yield("{\"statement\":\"SELECT 1\"}\n", nil)
         .and_yield("[\"n\"]\n", nil)
         .and_yield("[1]\n", nil)

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -54,14 +54,13 @@ RSpec.describe Altertable::Lakehouse::Client do
     it "appends a row and returns ok: true" do
       table_name = "append_events_#{SecureRandom.hex(4)}"
 
-      # Ensure the table exists first via upload (CSV create)
+      # Ensure the table exists first via upsert (CSV create)
       csv = "user_id,name\n1,Alice\n"
-      client.upload(
+      client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        content_type: "text/csv",
         file_io: StringIO.new(csv)
       )
 
@@ -78,12 +77,11 @@ RSpec.describe Altertable::Lakehouse::Client do
       table_name = "append_events_batch_#{SecureRandom.hex(4)}"
 
       csv = "user_id,name\n1,Alice\n"
-      client.upload(
+      client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        content_type: "text/csv",
         file_io: StringIO.new(csv)
       )
 
@@ -110,12 +108,11 @@ RSpec.describe Altertable::Lakehouse::Client do
       table_name = "append_events_sync_#{SecureRandom.hex(4)}"
 
       csv = "user_id,name\n1,Alice\n"
-      client.upload(
+      client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        content_type: "text/csv",
         file_io: StringIO.new(csv)
       )
 
@@ -240,23 +237,21 @@ RSpec.describe Altertable::Lakehouse::Client do
       client.query(statement: "SELECT 1", headers: { "X-Trace" => "trace-1" }).to_a
     end
 
-    it "forwards per-request headers and content type on #upload" do
+    it "forwards per-request headers on #upsert without content type" do
       expect(adapter).to receive(:post).with(
         "/upsert",
         hash_including(
           headers: {
-            "X-Upload-Source" => "etl",
-            "Content-Type" => "text/csv"
+            "X-Upload-Source" => "etl"
           }
         )
       ).and_return(ok_response)
 
-      client.upload(
+      client.upsert(
         catalog: "memory",
         schema: "main",
         table: "t",
         mode: "create",
-        content_type: "text/csv",
         file_io: StringIO.new("id\n1\n"),
         headers: { "X-Upload-Source" => "etl" }
       )
@@ -284,18 +279,17 @@ RSpec.describe Altertable::Lakehouse::Client do
     end
   end
 
-  # ── #upload ──────────────────────────────────────────────────────────────────
+  # ── #upsert ──────────────────────────────────────────────────────────────────
 
-  describe "#upload" do
+  describe "#upsert" do
     it "creates a table from CSV in create mode and allows querying it" do
       table_name = "upload_test_#{SecureRandom.hex(4)}"
       csv = "id,score\n10,100\n20,200\n"
-      client.upload(
+      client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        content_type: "text/csv",
         file_io: StringIO.new(csv)
       )
 

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe Altertable::Lakehouse::Client do
     it "appends a row and returns ok: true" do
       table_name = "append_events_#{SecureRandom.hex(4)}"
 
-      # Ensure the table exists first via upsert.
-      json = "{\"user_id\":1,\"name\":\"Alice\"}\n"
+      # Ensure the table exists first via upsert (CSV create)
+      csv = "user_id,name\n1,Alice\n"
       client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        file_io: StringIO.new(json)
+        file_io: StringIO.new(csv)
       )
 
       resp = client.append(
@@ -76,13 +76,13 @@ RSpec.describe Altertable::Lakehouse::Client do
     it "appends an array of rows and returns ok: true" do
       table_name = "append_events_batch_#{SecureRandom.hex(4)}"
 
-      json = "{\"user_id\":1,\"name\":\"Alice\"}\n"
+      csv = "user_id,name\n1,Alice\n"
       client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        file_io: StringIO.new(json)
+        file_io: StringIO.new(csv)
       )
 
       resp = client.append(
@@ -107,13 +107,13 @@ RSpec.describe Altertable::Lakehouse::Client do
     it "supports the sync query parameter" do
       table_name = "append_events_sync_#{SecureRandom.hex(4)}"
 
-      json = "{\"user_id\":1,\"name\":\"Alice\"}\n"
+      csv = "user_id,name\n1,Alice\n"
       client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        file_io: StringIO.new(json)
+        file_io: StringIO.new(csv)
       )
 
       resp = client.append(
@@ -282,15 +282,15 @@ RSpec.describe Altertable::Lakehouse::Client do
   # ── #upsert ──────────────────────────────────────────────────────────────────
 
   describe "#upsert" do
-    it "creates a table from JSON in create mode and allows querying it" do
+    it "creates a table from CSV in create mode and allows querying it" do
       table_name = "upload_test_#{SecureRandom.hex(4)}"
-      json = "{\"id\":10,\"score\":100}\n{\"id\":20,\"score\":200}\n"
+      csv = "id,score\n10,100\n20,200\n"
       client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        file_io: StringIO.new(json)
+        file_io: StringIO.new(csv)
       )
 
       result = client.query_all(statement: "SELECT * FROM #{table_name} ORDER BY id")

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Altertable::Lakehouse::Client do
         catalog: "memory",
         schema: "main",
         table: table_name,
-        format: "csv",
         mode: "create",
+        content_type: "text/csv",
         file_io: StringIO.new(csv)
       )
 
@@ -82,8 +82,8 @@ RSpec.describe Altertable::Lakehouse::Client do
         catalog: "memory",
         schema: "main",
         table: table_name,
-        format: "csv",
         mode: "create",
+        content_type: "text/csv",
         file_io: StringIO.new(csv)
       )
 
@@ -114,8 +114,8 @@ RSpec.describe Altertable::Lakehouse::Client do
         catalog: "memory",
         schema: "main",
         table: table_name,
-        format: "csv",
         mode: "create",
+        content_type: "text/csv",
         file_io: StringIO.new(csv)
       )
 
@@ -242,7 +242,7 @@ RSpec.describe Altertable::Lakehouse::Client do
 
     it "forwards per-request headers on #upload while keeping octet-stream content type" do
       expect(adapter).to receive(:post).with(
-        "/upload",
+        "/upsert",
         hash_including(
           headers: {
             "X-Upload-Source" => "etl",
@@ -255,8 +255,8 @@ RSpec.describe Altertable::Lakehouse::Client do
         catalog: "memory",
         schema: "main",
         table: "t",
-        format: "csv",
         mode: "create",
+        content_type: "text/csv",
         file_io: StringIO.new("id\n1\n"),
         headers: { "X-Upload-Source" => "etl" }
       )
@@ -294,8 +294,8 @@ RSpec.describe Altertable::Lakehouse::Client do
         catalog: "memory",
         schema: "main",
         table: table_name,
-        format: "csv",
         mode: "create",
+        content_type: "text/csv",
         file_io: StringIO.new(csv)
       )
 

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe Altertable::Lakehouse::Client do
     it "appends a row and returns ok: true" do
       table_name = "append_events_#{SecureRandom.hex(4)}"
 
-      # Ensure the table exists first via upsert (CSV create)
-      csv = "user_id,name\n1,Alice\n"
+      # Ensure the table exists first via upsert.
+      json = "{\"user_id\":1,\"name\":\"Alice\"}\n"
       client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        file_io: StringIO.new(csv)
+        file_io: StringIO.new(json)
       )
 
       resp = client.append(
@@ -76,13 +76,13 @@ RSpec.describe Altertable::Lakehouse::Client do
     it "appends an array of rows and returns ok: true" do
       table_name = "append_events_batch_#{SecureRandom.hex(4)}"
 
-      csv = "user_id,name\n1,Alice\n"
+      json = "{\"user_id\":1,\"name\":\"Alice\"}\n"
       client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        file_io: StringIO.new(csv)
+        file_io: StringIO.new(json)
       )
 
       resp = client.append(
@@ -107,13 +107,13 @@ RSpec.describe Altertable::Lakehouse::Client do
     it "supports the sync query parameter" do
       table_name = "append_events_sync_#{SecureRandom.hex(4)}"
 
-      csv = "user_id,name\n1,Alice\n"
+      json = "{\"user_id\":1,\"name\":\"Alice\"}\n"
       client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        file_io: StringIO.new(csv)
+        file_io: StringIO.new(json)
       )
 
       resp = client.append(
@@ -282,15 +282,15 @@ RSpec.describe Altertable::Lakehouse::Client do
   # ── #upsert ──────────────────────────────────────────────────────────────────
 
   describe "#upsert" do
-    it "creates a table from CSV in create mode and allows querying it" do
+    it "creates a table from JSON in create mode and allows querying it" do
       table_name = "upload_test_#{SecureRandom.hex(4)}"
-      csv = "id,score\n10,100\n20,200\n"
+      json = "{\"id\":10,\"score\":100}\n{\"id\":20,\"score\":200}\n"
       client.upsert(
         catalog: "memory",
         schema: "main",
         table: table_name,
         mode: "create",
-        file_io: StringIO.new(csv)
+        file_io: StringIO.new(json)
       )
 
       result = client.query_all(statement: "SELECT * FROM #{table_name} ORDER BY id")


### PR DESCRIPTION
## Summary
- Rename the public file write API from `upload` to `upsert`.
- Remove the upsert `content_type` keyword and stop sending a `Content-Type` header for raw upsert bodies.
- Stop setting `Content-Type: application/json` as a global adapter default; JSON endpoints now set it per request only.
- Update RBS/RBI signatures, specs, changelog, and README.
- Keep the `/upsert` endpoint and optional `mode` query parameter.

## Impact analysis
- Public API changes: callers now use `client.upsert(...)`; `content_type:` is no longer accepted for upsert.
- Tests/docs changed: specs now assert custom headers still pass through without forcing `Content-Type`; CSV upsert fixtures remain CSV to verify backend inference.
- Cross-SDK scope: same feedback is applied to Go, JS, Python, Rust, and PHP.

## Validation
- `git diff --check`
- Not run locally: `bundle exec rake spec`; Ruby/Bundler are not installed in this container.

## Notes
Earlier failing CI runs still sent `Content-Type: application/json` because Ruby had that header in adapter defaults. This PR now removes that default and keeps JSON content type scoped to JSON request bodies only.
