### PR TITLE
chore: update client specs to v0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,17 +143,33 @@ result.each do |row|
 end
 ```
 
-### `upsert`
+### `upload`
 
-Upserts a file (CSV, Parquet, etc.) to a table.
+Uploads a file (CSV, Parquet, etc.) to create, append, or overwrite a table.
 
 ```ruby
 File.open("data.csv", "rb") do |file|
-  client.upsert(
+  client.upload(
     catalog: "main",
     schema: "public",
     table: "events",
     mode: "append",
+    file_io: file
+  )
+end
+```
+
+### `upsert`
+
+Upserts a file by matching rows on a primary key.
+
+```ruby
+File.open("updates.csv", "rb") do |file|
+  client.upsert(
+    catalog: "main",
+    schema: "public",
+    table: "events",
+    primary_key: "id",
     file_io: file
   )
 end

--- a/lib/altertable/lakehouse/client.rb
+++ b/lib/altertable/lakehouse/client.rb
@@ -87,15 +87,29 @@ module Altertable
         }
       end
 
-      # POST /upsert
-      def upsert(catalog:, schema:, table:, file_io:, mode: nil, primary_key: nil, headers: {})
+      # POST /upload
+      def upload(catalog:, schema:, table:, mode:, file_io:, headers: {})
         params = {
           catalog: catalog,
           schema: schema,
-          table: table
+          table: table,
+          mode: mode
         }
-        params[:mode] = mode if mode
-        params[:primary_key] = primary_key if primary_key
+
+        body = file_io.respond_to?(:read) ? file_io.read : file_io
+
+        resp = @adapter.post("/upload", body: body, params: params, headers: headers)
+        handle_response(resp)
+      end
+
+      # POST /upsert
+      def upsert(catalog:, schema:, table:, primary_key:, file_io:, headers: {})
+        params = {
+          catalog: catalog,
+          schema: schema,
+          table: table,
+          primary_key: primary_key
+        }
 
         body = file_io.respond_to?(:read) ? file_io.read : file_io
 

--- a/rbi/altertable/lakehouse.rbi
+++ b/rbi/altertable/lakehouse.rbi
@@ -96,13 +96,24 @@ module Altertable
           catalog: String,
           schema: String,
           table: String,
+          mode: String,
           file_io: T.untyped,
-          mode: T.nilable(String),
-          primary_key: T.nilable(String),
           headers: T::Hash[String, String]
         ).returns(T.untyped)
       end
-      def upsert(catalog:, schema:, table:, file_io:, mode: nil, primary_key: nil, headers: {}); end
+      def upload(catalog:, schema:, table:, mode:, file_io:, headers: {}); end
+
+      sig do
+        params(
+          catalog: String,
+          schema: String,
+          table: String,
+          primary_key: String,
+          file_io: T.untyped,
+          headers: T::Hash[String, String]
+        ).returns(T.untyped)
+      end
+      def upsert(catalog:, schema:, table:, primary_key:, file_io:, headers: {}); end
 
       sig { params(query_id: String, headers: T::Hash[String, String]).returns(::Altertable::Lakehouse::Models::QueryLogResponse) }
       def get_query(query_id, headers: {}); end

--- a/sig/altertable/lakehouse/client.rbs
+++ b/sig/altertable/lakehouse/client.rbs
@@ -39,13 +39,21 @@ module Altertable
 
       def query_all: (statement: String, ?headers: ::Hash[String, String], **untyped options) -> ::Hash[Symbol, untyped]
 
+      def upload: (
+        catalog: String,
+        schema: String,
+        table: String,
+        mode: String,
+        file_io: untyped,
+        ?headers: ::Hash[String, String]
+      ) -> untyped
+
       def upsert: (
         catalog: String,
         schema: String,
         table: String,
+        primary_key: String,
         file_io: untyped,
-        ?mode: String?,
-        ?primary_key: String?,
         ?headers: ::Hash[String, String]
       ) -> untyped
 

--- a/spec/altertable/lakehouse_spec.rb
+++ b/spec/altertable/lakehouse_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe Altertable::Lakehouse::Client do
     it "appends a row and returns ok: true" do
       table_name = "append_events_#{SecureRandom.hex(4)}"
 
-      # Ensure the table exists first via upsert (CSV create)
+      # Ensure the table exists first via upload (CSV create)
       csv = "user_id,name\n1,Alice\n"
-      client.upsert(
+      client.upload(
         catalog: "memory",
         schema: "main",
         table: table_name,
@@ -78,7 +78,7 @@ RSpec.describe Altertable::Lakehouse::Client do
       table_name = "append_events_batch_#{SecureRandom.hex(4)}"
 
       csv = "user_id,name\n1,Alice\n"
-      client.upsert(
+      client.upload(
         catalog: "memory",
         schema: "main",
         table: table_name,
@@ -109,7 +109,7 @@ RSpec.describe Altertable::Lakehouse::Client do
       table_name = "append_events_sync_#{SecureRandom.hex(4)}"
 
       csv = "user_id,name\n1,Alice\n"
-      client.upsert(
+      client.upload(
         catalog: "memory",
         schema: "main",
         table: table_name,
@@ -238,9 +238,9 @@ RSpec.describe Altertable::Lakehouse::Client do
       client.query(statement: "SELECT 1", headers: { "X-Trace" => "trace-1" }).to_a
     end
 
-    it "forwards per-request headers on #upsert without content type" do
+    it "forwards per-request headers on #upload without content type" do
       expect(adapter).to receive(:post).with(
-        "/upsert",
+        "/upload",
         hash_including(
           headers: {
             "X-Upload-Source" => "etl"
@@ -248,7 +248,7 @@ RSpec.describe Altertable::Lakehouse::Client do
         )
       ).and_return(ok_response)
 
-      client.upsert(
+      client.upload(
         catalog: "memory",
         schema: "main",
         table: "t",
@@ -285,13 +285,13 @@ RSpec.describe Altertable::Lakehouse::Client do
     end
   end
 
-  # ── #upsert ──────────────────────────────────────────────────────────────────
+  # ── #upload ──────────────────────────────────────────────────────────────────
 
-  describe "#upsert" do
+  describe "#upload" do
     it "creates a table from CSV in create mode and allows querying it" do
       table_name = "upload_test_#{SecureRandom.hex(4)}"
       csv = "id,score\n10,100\n20,200\n"
-      client.upsert(
+      client.upload(
         catalog: "memory",
         schema: "main",
         table: table_name,
@@ -304,6 +304,36 @@ RSpec.describe Altertable::Lakehouse::Client do
       expect(result[:rows]).to eq([
         { "id" => 10, "score" => 100 },
         { "id" => 20, "score" => 200 }
+      ])
+    end
+  end
+
+  # ── #upsert ──────────────────────────────────────────────────────────────────
+
+  describe "#upsert" do
+    it "upserts rows by primary key" do
+      table_name = "upsert_test_#{SecureRandom.hex(4)}"
+      client.upload(
+        catalog: "memory",
+        schema: "main",
+        table: table_name,
+        mode: "create",
+        file_io: StringIO.new("id,score\n1,100\n2,200\n")
+      )
+
+      client.upsert(
+        catalog: "memory",
+        schema: "main",
+        table: table_name,
+        primary_key: "id",
+        file_io: StringIO.new("id,score\n2,250\n3,300\n")
+      )
+
+      result = client.query_all(statement: "SELECT * FROM #{table_name} ORDER BY id")
+      expect(result[:rows]).to eq([
+        { "id" => 1, "score" => 100 },
+        { "id" => 2, "score" => 250 },
+        { "id" => 3, "score" => 300 }
       ])
     end
   end


### PR DESCRIPTION
## Summary
- bump the `specs` submodule from `v0.11.0` to `v0.12.0`
- split the Lakehouse ingestion client API into `upload` and primary-key `upsert`
- update README, RBS/RBI signatures, and tests for the new API shape

## Spec Diff
- Lakehouse: split ingestion into `upload` (`create`, `append`, `overwrite`) and `upsert` (primary-key merge)
- Product Analytics: no spec files changed between `v0.11.0` and `v0.12.0`
- Shared: `rest/SPEC.md` was added upstream

## Validation
- GitHub Actions: typing, lint, and Ruby 3.2/3.3/3.4/4.0 tests pass
- Local Ruby tests were not run because `bundle` is not installed in this worker
