### PR TITLE
ci: add semantic PR title workflow

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,34 @@
+name: Semantic Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pr:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            revert
+            docs
+            style
+            chore
+            refactor
+            test
+            build
+            ci


### PR DESCRIPTION
## Summary
- add the shared semantic PR title workflow
- validate PR titles on open, edit, and synchronize events

## Impact
This keeps squash-merge titles compatible with Release Please and matches the shared SDK release automation guardrail already being rolled out across the ecosystem.

## Verification
- Not run locally; workflow-only change copied from the managed sdk-sync template.
