### PR TITLE
chore: render Ruby issue form label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
   - type: input
     id: runtime
     attributes:
-      label: "{language} Version"
+      label: "Ruby Version"
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
## Summary

- replace the unrendered `{language}` placeholder in the Ruby bug-report form with `Ruby`

## Impact

The change affects only the GitHub issue-form label shown to Lakehouse Ruby contributors. It restores the intended per-SDK rendering without changing the SDK API, runtime behavior, or release process.

## Validation

- `git diff --check`
- reviewed the resulting GitHub issue-form YAML diff

The local Ruby executable is unavailable in this environment, so YAML parsing will be covered by GitHub's workflow validation.
