### PR TITLE
ci: enforce semantic PR workflow policy

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,4 +1,5 @@
 name: Semantic Pull Request
+
 on:
   pull_request_target:
     types:
@@ -6,12 +7,21 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: semantic-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Validate pull request title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

- sync the semantic pull-request workflow to the shared policy
- pin the runner to Ubuntu 24.04 and the semantic-title action to its reviewed commit
- apply least-privilege permissions, bounded runtime, and per-PR concurrency

## Validation

- git diff --check
- exact byte comparison with the canonical semantic-workflow template
- bash scripts/validate-workflow-policy.sh . still reports the existing ci.yml runner policy drift; that unrelated workflow is intentionally out of scope for this focused PR

## Impact

This changes only pull-request title validation infrastructure. It does not change the SDK API or release artifacts.
